### PR TITLE
MS Short image - fix css issue in firefox browser

### DIFF
--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -279,8 +279,7 @@
 		margin: 0px;
 		border-radius: 5px 5px 0px 0px;
 		height: 190px;
-		width: fit-content;
-		object-fit: cover;
+		object-fit: contain;
 	}
 
 	.card-body {


### PR DESCRIPTION
Before - 
![image](https://user-images.githubusercontent.com/74607482/163605076-2e15b647-b2ec-4e86-b854-f726846ff115.png)
Now -
![image](https://user-images.githubusercontent.com/74607482/163605132-17919555-083b-4238-8524-2ac959e44fdf.png)

Now it shows the same in chrome and Firefox.