### PR TITLE
ci: add github actions workflow for lint, prettier, and build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - development
+  pull_request:
+    branches:
+      - master
+      - development
+
+#cancel an in progress run if a newer commit is pushed to the same branch/PR
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+#only reads the repo and runs checks and no write access needed
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run Prettier Check
+        run: npm run check-format
+
+      - name: Run Lint
+        run: npm run check-lint
+
+      - name: Run Type Check
+        run: npm run check-types
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Closes #276

## Summary
Adds `.github/workflows/ci.yml`, which runs on every push and pull request to `master` and `development` and validates the codebase with the project's existing scripts:

- Prettier formatting - `npm run check-format`
- ESLint - `npm run check-lint`
- TypeScript types - `npm run check-types`
- Production build - `npm run build`

## Notes on a few decisions
- Script names: the issue referenced `format-check` and `lint`, but the repo's actual scripts are `check-format` and `check-lint` (the `check-*` convention), so I used those - no `package.json` changes were needed.
- Install uses `npm ci --legacy-peer-deps`.
- Node is pinned to 18.

## Testing
- All four steps pass on a clean `development` checkout, including the build with `CI=true` (the GitHub Actions default).
- Verified the workflow catches a real problem by pushing an intentional formatting/lint error. Prettier and ESLint both flagged it and the run went red, then reverted it so this PR is green. Visible in this PR's run history.