### PR TITLE
Centralize environment variables into configs/index.ts

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -3,6 +3,7 @@ import { ApplicationConstants } from "../../constants";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { translation } from "../../locales/en-US/translation.json";
+import configs from "../../configs";
 
 const NavBar: React.FC = () => {
 	const state = useSelector((state) => state.userReducer);
@@ -77,7 +78,7 @@ const NavBar: React.FC = () => {
 								aria-expanded="false"
 							>
 								<img
-									src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${imagePath}`}
+									src={`${configs.storage.storageUrl}${imagePath}`}
 									className="rounded-circle"
 									height="35"
 									alt="Black and White Portrait of a Man"

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,0 +1,18 @@
+const configs = {
+	storage: {
+		bucketUrl: process.env.REACT_APP_STORAGE_BUCKET_URL ?? "",
+		bucketName: process.env.REACT_APP_STORAGE_BUCKET_NAME ?? "",
+		storageUrl: `${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/`,
+	},
+	api: {
+		baseUrl: process.env.REACT_APP_API_ENDPOINT ?? "",
+	},
+	app: {
+		env: process.env.NODE_ENV ?? "development",
+	},
+	scheduler: {
+		url: process.env.REACT_APP_MS_SCHEDULER ?? "",
+	},
+};
+
+export default configs;

--- a/src/pages/dashboard/login_info/index.tsx
+++ b/src/pages/dashboard/login_info/index.tsx
@@ -4,6 +4,7 @@ import Loader from "../loader";
 import { useDispatch, useSelector } from "react-redux";
 import { IRecentLogin } from "../../../interfaces/ILogins";
 import { getLoginInfo } from "../../../store/logins-store/loginsActions";
+import configs from "../../../configs";
 
 const RecentLogin: React.FC = () => {
 	const recentLogins = useSelector((state) => state.loginsReducer);
@@ -12,7 +13,7 @@ const RecentLogin: React.FC = () => {
 		dispatch(getLoginInfo());
 	}, [dispatch]);
 
-	const URL = `${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/`;
+	const URL = `${configs.storage.storageUrl}`;
 
 	return (
 		<div className="resent__login">

--- a/src/pages/dashboard/meeting_scheduler/index.tsx
+++ b/src/pages/dashboard/meeting_scheduler/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const MeetingScheduler: React.FC = () => {
 	return (
@@ -12,7 +13,7 @@ const MeetingScheduler: React.FC = () => {
 				<div className="card-body">
 					<img className="card-img-top" src="/images/meetingscheduler.svg" alt="urlshort-img" />
 					<p className="mt-2">{translation.dashboard["meeting-scheduler"].description}</p>
-					<a href={process.env.REACT_APP_MS_SCHEDULER} rel="noreferrer" target="_blank">
+					<a href={configs.scheduler.url} rel="noreferrer" target="_blank">
 						<button className="btn btn-primary">{translation.dashboard["meeting-scheduler"]["schduler-button"]}</button>
 					</a>
 				</div>

--- a/src/pages/event/list/delete.tsx
+++ b/src/pages/event/list/delete.tsx
@@ -10,6 +10,7 @@ import paginationFactory from "react-bootstrap-table2-paginator";
 import moment from "moment";
 import { useHistory } from "react-router-dom";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const DeletedEventList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -117,7 +118,7 @@ const DeletedEventList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -198,11 +199,7 @@ const DeletedEventList: React.FC = () => {
 				<h5>{translation["table-row-information"]["event-information"]["event-information-title"]}</h5>
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
-						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
-							className="event-flyer"
-							alt="event-flyer"
-						/>
+						<img src={`${configs.storage.storageUrl}${row.imageUrl}`} className="event-flyer" alt="event-flyer" />
 					</div>
 					<div className="col-md-9 col-sm-12">
 						<h6 className="row-header">

--- a/src/pages/event/list/index.tsx
+++ b/src/pages/event/list/index.tsx
@@ -13,6 +13,7 @@ import UpdateEvent from "../update";
 import DeleteEvent from "../delete";
 import { useHistory } from "react-router-dom";
 import EventLoader from "../loader";
+import configs from "../../../configs";
 
 const EventList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -113,7 +114,7 @@ const EventList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -205,11 +206,7 @@ const EventList: React.FC = () => {
 				<h5>{translation["table-row-information"]["event-information"]["event-information-title"]}</h5>
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
-						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
-							className="event-flyer"
-							alt="event-flyer"
-						/>
+						<img src={`${configs.storage.storageUrl}${row.imageUrl}`} className="event-flyer" alt="event-flyer" />
 					</div>
 					<div className="col-md-9 col-sm-12">
 						<h6 className="row-header">

--- a/src/pages/event/update/index.tsx
+++ b/src/pages/event/update/index.tsx
@@ -7,6 +7,7 @@ import moment from "moment";
 import RichTextEditor from "react-rte";
 import { ToolBarConfig } from "../../../constants";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 let formData: IEventFormData = {
 	imageSrc: null,
@@ -200,7 +201,7 @@ const UpdateEvent: React.FC = () => {
 								<div className="col-md-6">
 									<span className="flyer-title">{translation.forms.event.edit["current-event-flyer"]}</span>
 									<img
-										src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${eventDetails?.imageUrl}`}
+										src={`${configs.storage.storageUrl}${eventDetails?.imageUrl}`}
 										className="flyer"
 										alt="event-flyer"
 									/>

--- a/src/pages/event/view/index.tsx
+++ b/src/pages/event/view/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import moment from "moment";
 import { IEvent } from "../../../interfaces";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const EventView: React.FC = () => {
 	const HtmlToReactParser = require("html-to-react").Parser;
@@ -152,8 +153,7 @@ const EventView: React.FC = () => {
 												<li key={index} className="modify-user-item">
 													<span className="d-flex my-0">
 														<img
-															src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/
-																${process.env.REACT_APP_STORAGE_BUCKET_NAME}/
+															src={`${configs.storage.storageUrl}
 																${user.user.profileImage}`}
 															className="profile-img"
 															alt="event-flyer"

--- a/src/pages/settings/organization/index.tsx
+++ b/src/pages/settings/organization/index.tsx
@@ -8,6 +8,7 @@ import {
 	createOrganization,
 } from "../../../store/organization-store/organizationActions";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const initialState: IIOrganizationState = {
 	organizationId: "",
@@ -142,11 +143,7 @@ const OrganizationInfo: React.FC = () => {
 					<div className="d-flex justify-content-center">
 						<div className="row">
 							{organization && organization.imagePath ? (
-								<img
-									src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${organization.imagePath}`}
-									alt="ms-club"
-									className="logo"
-								/>
+								<img src={`${configs.storage.storageUrl}${organization.imagePath}`} alt="ms-club" className="logo" />
 							) : (
 								<img src="/images/ms_club_logo.png" alt="ms-club" className="logo" />
 							)}

--- a/src/pages/settings/users/list/index.tsx
+++ b/src/pages/settings/users/list/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setUserId } from "../../../../store/user-store/userActions";
+import configs from "../../../../configs";
 interface IUserProps {
 	id: string;
 	firstName: string;
@@ -42,10 +43,7 @@ const User: React.FC<IUserProps> = (props: IUserProps) => {
 			<div className="card border shadow-none">
 				<div className="row">
 					<div className="col-md-4">
-						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${props.imagePath}`}
-							className="image"
-						/>
+						<img src={`${configs.storage.storageUrl}${props.imagePath}`} className="image" />
 					</div>
 
 					<div className="col-md-8">

--- a/src/pages/settings/users/view/index.tsx
+++ b/src/pages/settings/users/view/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import ImageCanvas from "../../../../components/image-canvas";
 import { IUser, IUserFormData, IUserState } from "../../../../interfaces";
 import { updateUser, getAllUsers, setUserId, adminUpdateUser } from "../../../../store/user-store/userActions";
+import configs from "../../../../configs";
 
 let formData: IUserFormData = {
 	firstName: null,
@@ -35,7 +36,7 @@ const ViewUser: React.FC = () => {
 	const [edit, setEdit] = useState<boolean>(false);
 	const [changePassword, setChangePassword] = useState<boolean>(false);
 	const dispatch = useDispatch();
-	const URL = process.env.REACT_APP_STORAGE_BUCKET_URL + "/" + process.env.REACT_APP_STORAGE_BUCKET_NAME + "/";
+	const URL = configs.storage.storageUrl;
 	const [imgURL, setImageURL] = useState<any>();
 	const [permission, setPermission] = useState<string>();
 

--- a/src/pages/top-speaker/list/delete.tsx
+++ b/src/pages/top-speaker/list/delete.tsx
@@ -10,6 +10,7 @@ import { useHistory } from "react-router-dom";
 import RecoverDeletedTopSpeaker from "../recover-delete";
 import PermanentDeleteTopSpeaker from "../permenent-delete";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const DeletedTopSpeakerList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -98,7 +99,7 @@ const DeletedTopSpeakerList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -189,7 +190,7 @@ const DeletedTopSpeakerList: React.FC = () => {
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
 						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
+							src={`${configs.storage.storageUrl}${row.imageUrl}`}
 							className="topSpeaker-flyer"
 							alt="topSpeaker-flyer"
 						/>

--- a/src/pages/top-speaker/list/index.tsx
+++ b/src/pages/top-speaker/list/index.tsx
@@ -13,6 +13,7 @@ import UpdateTopSpeaker from "../update";
 import DeleteTopSpeaker from "../delete";
 import TopSpeakerLoader from "../loader";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const TopSpeakerList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -107,7 +108,7 @@ const TopSpeakerList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -201,7 +202,7 @@ const TopSpeakerList: React.FC = () => {
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
 						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
+							src={`${configs.storage.storageUrl}${row.imageUrl}`}
 							className="topSpeaker-flyer"
 							alt="topSpeaker-flyer"
 						/>

--- a/src/pages/top-speaker/update/index.tsx
+++ b/src/pages/top-speaker/update/index.tsx
@@ -6,6 +6,7 @@ import ImageCanvas from "../../../components/image-canvas";
 import RichTextEditor from "react-rte";
 import { ToolBarConfig } from "../../../constants";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 let formData: ITopSpeakerFormData = {
 	imageSrc: null,
@@ -190,7 +191,7 @@ const UpdateTopSpeaker: React.FC = () => {
 									{translation.forms["top-speakers"].edit["current-top-speakers-image"]}
 								</span>
 								<img
-									src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${topSpeakerDetails?.imageUrl}`}
+									src={`${configs.storage.storageUrl}${topSpeakerDetails?.imageUrl}`}
 									className="flyer"
 									alt="top-speaker-image"
 								/>

--- a/src/pages/top-speaker/view/index.tsx
+++ b/src/pages/top-speaker/view/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import moment from "moment";
 import { ITopSpeaker } from "../../../interfaces";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const TopSpeakerView: React.FC = () => {
 	const HtmlToReactParser = require("html-to-react").Parser;
@@ -167,8 +168,7 @@ const TopSpeakerView: React.FC = () => {
 												<li key={index} className="modify-user-item">
 													<span className="d-flex my-0">
 														<img
-															src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/
-																${process.env.REACT_APP_STORAGE_BUCKET_NAME}/
+															src={`${configs.storage.storageUrl}
 																${user.user.profileImage}`}
 															className="profile-img"
 															alt="event-flyer"

--- a/src/pages/webinar/list/delete.tsx
+++ b/src/pages/webinar/list/delete.tsx
@@ -10,6 +10,7 @@ import moment from "moment";
 import { useHistory } from "react-router-dom";
 import RecoverDeletedWebinar from "../recover-delete";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const DeletedWebinarList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -110,7 +111,7 @@ const DeletedWebinarList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -198,11 +199,7 @@ const DeletedWebinarList: React.FC = () => {
 				<h5>{translation["table-row-information"]["webinar-information"]["webinar-information-title"]}</h5>
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
-						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
-							className="event-flyer"
-							alt="event-flyer"
-						/>
+						<img src={`${configs.storage.storageUrl}${row.imageUrl}`} className="event-flyer" alt="event-flyer" />
 					</div>
 					<div className="col-md-9 col-sm-12">
 						<h6 className="row-header">

--- a/src/pages/webinar/list/index.tsx
+++ b/src/pages/webinar/list/index.tsx
@@ -13,6 +13,7 @@ import { useHistory } from "react-router-dom";
 import AddWebinar from "../add";
 import WebinarLoader from "../loader";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const WebinarList: React.FC = () => {
 	const dispatch = useDispatch();
@@ -113,7 +114,7 @@ const WebinarList: React.FC = () => {
 					<div>
 						<span>
 							<img
-								src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${lastModifiedUser.user.profileImage}`}
+								src={`${configs.storage.storageUrl}${lastModifiedUser.user.profileImage}`}
 								className="table-profile-img"
 								alt="updated-by-user"
 							/>
@@ -198,11 +199,7 @@ const WebinarList: React.FC = () => {
 				<h5>{translation["table-row-information"]["webinar-information"]["webinar-information-title"]}</h5>
 				<div className="row">
 					<div className="col-md-3 col-sm-12">
-						<img
-							src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${row.imageUrl}`}
-							className="event-flyer"
-							alt="event-flyer"
-						/>
+						<img src={`${configs.storage.storageUrl}${row.imageUrl}`} className="event-flyer" alt="event-flyer" />
 					</div>
 					<div className="col-md-9 col-sm-12">
 						<h6 className="row-header">

--- a/src/pages/webinar/update/index.tsx
+++ b/src/pages/webinar/update/index.tsx
@@ -7,6 +7,7 @@ import moment from "moment";
 import RichTextEditor from "react-rte";
 import { ToolBarConfig } from "../../../constants";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 let formData: IwebinarFormData = {
 	imageSrc: null,
@@ -200,7 +201,7 @@ const UpdateWebinar: React.FC = () => {
 								<div className="col-md-6">
 									<span className="flyer-title">{translation.forms.webinar.edit["current-webinar-flyer"]}</span>
 									<img
-										src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/${process.env.REACT_APP_STORAGE_BUCKET_NAME}/${webinarDetails?.imageUrl}`}
+										src={`${configs.storage.storageUrl}${webinarDetails?.imageUrl}`}
 										className="flyer"
 										alt="webinar-flyer"
 									/>

--- a/src/pages/webinar/view/index.tsx
+++ b/src/pages/webinar/view/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import moment from "moment";
 import { IWebinar } from "../../../interfaces";
 import { translation } from "../../../locales/en-US/translation.json";
+import configs from "../../../configs";
 
 const WebinarView: React.FC = () => {
 	const HtmlToReactParser = require("html-to-react").Parser;
@@ -167,8 +168,7 @@ const WebinarView: React.FC = () => {
 												<li key={index} className="modify-user-item">
 													<span className="d-flex my-0">
 														<img
-															src={`${process.env.REACT_APP_STORAGE_BUCKET_URL}/
-																${process.env.REACT_APP_STORAGE_BUCKET_NAME}/
+															src={`${configs.storage.storageUrl}
 																${user.user.profileImage}`}
 															className="profile-img"
 															alt="event-flyer"

--- a/src/store/api/ApplicationAPI.ts
+++ b/src/store/api/ApplicationAPI.ts
@@ -2,8 +2,9 @@ import axios from "axios";
 import { IApplication } from "../../interfaces";
 import requestConfig from "./config";
 import requestConfigJson from "./configJson";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class ApplicationAPI {
 	static createApplication(applicationData: IApplication): Promise<IApplication> {

--- a/src/store/api/EventAPI.ts
+++ b/src/store/api/EventAPI.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { IEvent } from "../../interfaces";
 import requestConfig from "./config";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class EventAPI {
 	static createEvent(eventData: IEvent): Promise<IEvent> {

--- a/src/store/api/InquiryAPI.ts
+++ b/src/store/api/InquiryAPI.ts
@@ -2,7 +2,8 @@ import axios from "axios";
 import requestConfig from "./config";
 import requestConfigJson from "./configJson";
 import { IInquiry } from "../../interfaces";
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+import configs from "../../configs";
+const BASE_URL = configs.api.baseUrl as string;
 
 class InquiryAPI {
 	static getInquiries(): Promise<IInquiry[]> {

--- a/src/store/api/LoginsAPI.ts
+++ b/src/store/api/LoginsAPI.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import requestConfig from "./config";
 import { IRecentLogin } from "../../interfaces/ILogins";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class LoginsAPI {
 	static getLoginInfo(): Promise<IRecentLogin[]> {

--- a/src/store/api/OrganizationAPI.ts
+++ b/src/store/api/OrganizationAPI.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { IOrganization } from "../../interfaces";
 import requestConfig from "./config";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class OrganizationAPI {
 	static createOrganization(organizationInfo: IOrganization): Promise<IOrganization> {

--- a/src/store/api/TopSpeakerAPI.ts
+++ b/src/store/api/TopSpeakerAPI.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import requestConfig from "./config";
 import { ITopSpeaker } from "../../interfaces";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class TopSpeakerAPI {
 	static createTopSpeaker(topSpeakerData: ITopSpeaker): Promise<ITopSpeaker> {

--- a/src/store/api/UserAPI.ts
+++ b/src/store/api/UserAPI.ts
@@ -2,8 +2,9 @@ import axios from "axios";
 import requestConfig from "./config";
 import requestConfigJson from "./configJson";
 import { IUser } from "../../interfaces";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class UserAPI {
 	static createUser(userData: IUser): Promise<IUser> {

--- a/src/store/api/WebinarAPI.ts
+++ b/src/store/api/WebinarAPI.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { IWebinar } from "../../interfaces";
 import requestConfig from "./config";
+import configs from "../../configs";
 
-const BASE_URL = process.env.REACT_APP_API_ENDPOINT as string;
+const BASE_URL = configs.api.baseUrl as string;
 
 class WebinarAPI {
 	static createWebinar(webinarData: IWebinar): Promise<IWebinar> {


### PR DESCRIPTION
Closes #287

Adds src/configs/index.ts as the single source of truth for environment variables. It is now the only place that reads process.env directly each variable is read once, given a safe fallback, and exported as a typed constant. The composed storage URL is pre built as configs.storage.storageUrl instead of being reconstructed at every call site.
All existing process.env references across the codebase are replaced with the corresponding configs import:

Testing: npm run check-format, npm run check-lint, npm run check-types, and npm run build all pass locally.